### PR TITLE
Fix assignment bar chart options 

### DIFF
--- a/client/src/Controllers/studentGradesController.js
+++ b/client/src/Controllers/studentGradesController.js
@@ -19,6 +19,9 @@ app.controller("studentGradesController", function ($scope, $rootScope, $routePa
                         min: 0,
                     },
                 }],
+                xAxes: [{
+                    maxBarThickness: 70,
+                }],
             },
         },
         colors: [],


### PR DESCRIPTION
Sets the min to 0, and sets a max bar width. Resolves #181 