### PR TITLE
fixed wording on tip bubbles for behavior page and speak to an admin bubbles

### DIFF
--- a/client/src/Views/studentBehaviors.html
+++ b/client/src/Views/studentBehaviors.html
@@ -2,7 +2,10 @@
 <div ng-if="!hasBehaviorService" class="row">
     <div class="col-xs-12">
         <div id="student-behaviors-service-warning" class="alert alert-warning" role="alert">
-            <span><b>Warning:</b> This student doesn't have a Behavior Service. If this student did in the past, you may view that history here. If not, you can add a Behavior Service to this student in order to start recording Behavior and Effort.</span>
+            <span>
+                <b>Warning:</b> This student doesn't have a Behavior Service. If this student did in the past, you may view that history here. 
+                <span ng-show="isSuperUser || isCaseManager">If not, you can add a Behavior Service to this student in order to start recording Behavior and Effort.</span>
+            </span>
         </div>
     </div>
 </div>

--- a/client/src/Views/studentGrades.html
+++ b/client/src/Views/studentGrades.html
@@ -3,7 +3,10 @@
     <div class="row">
         <div class="col-xs-12">
             <div class="alert alert-info no-bottom-margin" role="alert">
-                <span><b>Tip:</b> It looks like this student isn't enrolled in any classes. Speak to an admin to add a class to this student's schedule.</span>
+                <span>
+                    <b>Tip:</b> It looks like this student isn't enrolled in any classes. 
+                    <span ng-show="!isSuperUser">Speak to an admin to add a class to this student's schedule.</span>
+                </span>
             </div>
         </div>
     </div>

--- a/client/src/Views/studentOverview.html
+++ b/client/src/Views/studentOverview.html
@@ -194,7 +194,10 @@
                         </div>
                     </div>
                     <div class="alert alert-info no-bottom-margin" ng-if="terms.length === 0">
-                        <span><b>Info:</b> It looks like this school doesn't have any terms yet. Speak to your admin to add one.</span>
+                        <span>
+                            <b>Info:</b> It looks like this school doesn't have any terms yet. 
+                            <span ng-show="!isSuperUser">Speak to your admin to add one.</span>
+                        </span>
                     </div>
                     <div class="alert alert-info no-bottom-margin voffset3" ng-if="terms.length > 0 && termSections.length === 0">
                         <span><b>Info:</b> It looks like this student either isn't enrolled in any classes for this term, or you aren't one of this student's teachers for this term.</span>

--- a/client/src/Views/studentTests.html
+++ b/client/src/Views/studentTests.html
@@ -2,7 +2,10 @@
 <div class="row" ng-if="tests.length === 0">
     <div class="col-xs-12">
         <div class="alert alert-info" role="alert">
-            <span><b>Tip:</b> It looks like you school hasn't created any standardized tests yet. Speak to your admin about adding one.</span>
+            <span>
+                <b>Tip:</b> It looks like you school hasn't created any standardized tests yet. 
+                <span ng-show="!isSuperUser">Speak to your admin about adding one.</span>
+            </span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
fixed wording on 'no behavior service warning' when you can't add one fixed 'speak to an admin' showing up when you're an admin.

resolves #499 
